### PR TITLE
Simclr test

### DIFF
--- a/simclr_test/grab_data.ipynb
+++ b/simclr_test/grab_data.ipynb
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 9,
    "id": "ab627ca3",
    "metadata": {},
    "outputs": [],
@@ -34,9 +34,8 @@
     "## In this cell, grab the directory where the data lives for both training and test,\n",
     "## as well as the subdirectories (labels) in each\n",
     "data_dir = './../fourthbrain-capstone/data/raw/OCT2017/'\n",
-    "\n",
     "training_dir = data_dir + 'train/'\n",
-    "test_dir = data_dir + 'test/''\n",
+    "test_dir = data_dir + 'test/'\n",
     "\n",
     "labels = [i for i in os.listdir(training_dir) if '.' not in i]"
    ]
@@ -101,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 30,
    "id": "6344b050",
    "metadata": {},
    "outputs": [],
@@ -109,11 +108,15 @@
     "##verify directory is where we want to be\n",
     "#os.listdir(data_dir)\n",
     "\n",
-    "##Make directory\n",
-    "#os.mkdir(data_dir + 'unlabeled_data_20k_images')\n",
-    "\n",
     "## set unlabeled path\n",
     "#unlabeled_dir = data_dir + 'unlabeled_data_20k_images'\n",
+    "##Make directory\n",
+    "#os.mkdir(unlabeled_dir)\n",
+    "\n",
+    "## update unlabeled path\n",
+    "#unlabeled_dir += '/data'\n",
+    "##Make directory\n",
+    "#os.mkdir(unlabeled_dir)\n",
     "\n",
     "##verify unlabeled_dir exists\n",
     "#assert 'unlabeled_data_20k_images' in os.listdir(data_dir)"
@@ -139,8 +142,11 @@
     "for label in labels:\n",
     "        temp_dir = training_dir+label+'/'\n",
     "        count = len(os.listdir(temp_dir))\n",
+    "        print(label,count)        \n",
     "        indices = random.sample(range(0,count), 5000)\n",
+    "        print('indice')\n",
     "        files = [os.listdir(temp_dir)[i] for i in indices]\n",
+    "        print(len(files))\n",
     "        for file in files:\n",
     "            temp_f = temp_dir+file\n",
     "            shutil.copy(temp_f,unlabeled_dir)\n",
@@ -157,7 +163,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 31,
    "id": "7d491946",
    "metadata": {},
    "outputs": [
@@ -167,7 +173,7 @@
        "20000"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -179,7 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "478ffd09",
+   "id": "bbf6d0ed",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/simclr_test/grab_data.ipynb
+++ b/simclr_test/grab_data.ipynb
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 1,
    "id": "4d07849f",
    "metadata": {},
    "outputs": [],
@@ -35,8 +35,8 @@
     "## as well as the subdirectories (labels) in each\n",
     "data_dir = './../fourthbrain-capstone/data/raw/OCT2017/'\n",
     "\n",
-    "training_dir = data_dir+'train/'\n",
-    "test_dir = data_dir + \"test/\"\n",
+    "training_dir = data_dir + 'train/'\n",
+    "test_dir = data_dir + 'test/''\n",
     "\n",
     "labels = [i for i in os.listdir(training_dir) if '.' not in i]"
    ]
@@ -52,9 +52,9 @@
      "output_type": "stream",
      "text": [
       "there are 37205 images in the CNV labels\n",
-      "there are 11343 images in the DME labels\n",
-      "there are 8614 images in the DRUSEN labels\n",
-      "there are 26303 images in the NORMAL labels\n"
+      "there are 11348 images in the DME labels\n",
+      "there are 8616 images in the DRUSEN labels\n",
+      "there are 26315 images in the NORMAL labels\n"
      ]
     }
    ],
@@ -80,8 +80,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "there are 83465 training total examples\n",
-      "there are 1001 test total examples\n"
+      "there are 83484 training total examples\n",
+      "there are 1000 test total examples\n"
      ]
     }
    ],
@@ -95,39 +95,28 @@
    "id": "a4b84ad4",
    "metadata": {},
    "source": [
-    "### New Directory:\n",
+    "### New directory for sampled 20k training images\n",
     "The cell below is to create a new data directory where we'll save our 20k images. The goal is to grab 5k per class, and save them to a single dir to serve as our unlabeled directory. If we were doing the full image set, this is unnecessary as we can use the <b>labels = None</b> argument in the <b>tf.keras.utils.image_dataset_from_directory</b> command"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 13,
    "id": "6344b050",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['limited_data', '.DS_Store', 'test', 'unlabeled_data_20k_images', 'train']"
-      ]
-     },
-     "execution_count": 45,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "##verify directory is where we want to be\n",
-    "# os.listdir('../fourthbrain-capstone/data/raw/OCT2017')\n",
+    "#os.listdir(data_dir)\n",
     "\n",
     "##Make directory\n",
-    "# os.mkdir('../fourthbrain-capstone/data/raw/OCT2017/unlabeled_data_20k_images')\n",
+    "#os.mkdir(data_dir + 'unlabeled_data_20k_images')\n",
     "\n",
     "## set unlabeled path\n",
-    "# unlabeled_dir = '../fourthbrain-capstone/data/raw/OCT2017/unlabeled_data_20k_images'\n",
+    "#unlabeled_dir = data_dir + 'unlabeled_data_20k_images'\n",
     "\n",
     "##verify unlabeled_dir exists\n",
-    "# os.listdir('../fourthbrain-capstone/data/raw/OCT2017')"
+    "#assert 'unlabeled_data_20k_images' in os.listdir(data_dir)"
    ]
   },
   {
@@ -141,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "id": "269d6165",
    "metadata": {},
    "outputs": [],
@@ -163,12 +152,12 @@
    "id": "0a284ef3",
    "metadata": {},
    "source": [
-    "Below, verify we have 2k images in unlabeled_dir"
+    "Below, verify we have 20k images in unlabeled_dir"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 17,
    "id": "7d491946",
    "metadata": {},
    "outputs": [
@@ -178,7 +167,7 @@
        "20000"
       ]
      },
-     "execution_count": 47,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -212,7 +201,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/simclr_test/simclr model V2.ipynb
+++ b/simclr_test/simclr model V2.ipynb
@@ -308,7 +308,7 @@
     "    input_shape=(image_size, image_size, image_channels))\n",
     "\n",
     "\n",
-    "def get_resnet_encoder(resnet, data, image_size, image_channels, width, n_classes):\n",
+    "def get_resnet_encoder(resnet, data, image_size, image_channels, width):\n",
     "    \"\"\"set up the get_resnet_encoder.\n",
     "        This model architecture will be used in the teacher net and passed to the student net\n",
     "    \n",
@@ -359,7 +359,7 @@
     }
    ],
    "source": [
-    "get_resnet_encoder(resnet50,labeled_train_dataset,image_size, image_channels, width, 4).summary()"
+    "get_resnet_encoder(resnet50,labeled_train_dataset,image_size, image_channels, width).summary()"
    ]
   },
   {
@@ -396,7 +396,7 @@
     "    [\n",
     "        keras.Input(shape=(image_size, image_size, image_channels)),\n",
     "        get_augmenter(**classification_augmentation),\n",
-    "        get_resnet_encoder(resnet50, labeled_train_dataset, image_size, image_channels, width, 3),\n",
+    "        get_resnet_encoder(resnet50, labeled_train_dataset, image_size, image_channels, width),\n",
     "        layers.Dense(4),\n",
     "    ],\n",
     "    name=\"baseline_model\",\n",
@@ -675,7 +675,7 @@
     "        self.temperature = temperature\n",
     "        self.contrastive_augmenter = get_augmenter(**contrastive_augmentation)\n",
     "        self.classification_augmenter = get_augmenter(**classification_augmentation)\n",
-    "        self.encoder =  get_resnet_encoder(resnet50, labeled_train_dataset, image_size, image_channels, width, 3)\n",
+    "        self.encoder =  get_resnet_encoder(resnet50, labeled_train_dataset, image_size, image_channels, width)\n",
     "        # Non-linear MLP as projection head - Note, output is of width width. This is okay as we use matrix calculations to reduce the size to a single loss value per step\n",
     "        self.projection_head = keras.Sequential(\n",
     "            [\n",

--- a/simclr_test/simclr model V2.ipynb
+++ b/simclr_test/simclr model V2.ipynb
@@ -23,6 +23,8 @@
    "id": "8b0dba57",
    "metadata": {},
    "source": [
+    "## set up paths, model parameters, and grab data\n",
+    "\n",
     "First, grab data directories, note: test_dir will contain the labeled data and training_dir needs to be entirely unlabeled"
    ]
   },
@@ -110,6 +112,14 @@
     "contrastive_augmentation = {\"min_area\": 0.25, \"brightness\": 0.6, \"jitter\": 0.2}\n",
     "classification_augmentation = {\"min_area\": 0.75, \"brightness\": 0.3, \"jitter\": 0.1}\n",
     "##jitter refers to the color scaling, brightness refers to strength of contrast, min_area cropping"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f79a400",
+   "metadata": {},
+   "source": [
+    "## Image augmentations"
    ]
   },
   {
@@ -293,6 +303,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "fbb20db6",
+   "metadata": {},
+   "source": [
+    "## encoder architecture"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 49,
    "id": "86cafcf1",
@@ -360,6 +378,14 @@
    ],
    "source": [
     "get_resnet_encoder(resnet50,labeled_train_dataset,image_size, image_channels, width).summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4e5d596",
+   "metadata": {},
+   "source": [
+    "## Supervised baseline model"
    ]
   },
   {
@@ -493,6 +519,14 @@
     "        max(baseline_history.history[\"val_acc\"]) * 100\n",
     "    )\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6c016c6d",
+   "metadata": {},
+   "source": [
+    "## Self-supervised model for contrastive pretraining"
    ]
   },
   {
@@ -837,6 +871,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "b733e8f8",
+   "metadata": {},
+   "source": [
+    "## Supervised finetuning of the pretrained encoder - Student Net"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 56,
    "id": "d1a82998",
@@ -909,7 +951,6 @@
     }
    ],
    "source": [
-    "# Supervised finetuning of the pretrained encoder - Student Net\n",
     "finetuning_model = keras.Sequential(\n",
     "    [\n",
     "        layers.Input(shape=(image_size, image_size, image_channels)),\n",
@@ -934,6 +975,14 @@
     "        max(finetuning_history.history[\"val_acc\"]) * 100\n",
     "    )\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d741707",
+   "metadata": {},
+   "source": [
+    "## Comparison against the baseline"
    ]
   },
   {
@@ -990,6 +1039,14 @@
     "\n",
     "\n",
     "plot_training_curves(pretraining_history, finetuning_history, baseline_history)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "96a08cb8",
+   "metadata": {},
+   "source": [
+    "## Save the models"
    ]
   },
   {
@@ -1519,7 +1576,6 @@
     }
    ],
    "source": [
-    "#Save the models\n",
     "model_dir = './models/'\n",
     "# os.mkdir(model_dir)\n",
     "# baseline_model.save(model_dir+'resnet50_20epochs_20k_unlabeled_1k_labeled')\n",

--- a/simclr_test/simclr model V2.ipynb
+++ b/simclr_test/simclr model V2.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "4d07849f",
    "metadata": {},
    "outputs": [],
@@ -35,7 +35,7 @@
    "source": [
     "data_dir = './../fourthbrain-capstone/data/raw/OCT2017/'\n",
     "test_dir = data_dir + \"test/\"\n",
-    "training_dir = '../fourthbrain-capstone/data/raw/OCT2017/unlabeled_data_20k_images'"
+    "training_dir = data_dir + 'unlabeled_data_20k_images'"
    ]
   },
   {
@@ -1552,7 +1552,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/simclr_test/simclr model V2_100_epocs.ipynb
+++ b/simclr_test/simclr model V2_100_epocs.ipynb
@@ -23,6 +23,7 @@
    "id": "9842ff7b",
    "metadata": {},
    "source": [
+    "## set up paths, model parameters, and grab data\n",
     "First, grab data directories, note: test_dir will contain the labeled data and training_dir needs to be entirely unlabeled"
    ]
   },
@@ -111,6 +112,14 @@
     "classification_augmentation = {\"min_area\": 0.75, \"brightness\": 0.3, \"jitter\": 0.1}\n",
     "\n",
     "##jitter refers to the color scaling, brightness refers to strength of contrast, min_area cropping"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "88e5d3ac",
+   "metadata": {},
+   "source": [
+    "## Image augmentations"
    ]
   },
   {
@@ -294,6 +303,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "75a8cf1d",
+   "metadata": {},
+   "source": [
+    "## encoder architecture"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 7,
    "id": "86cafcf1",
@@ -360,6 +377,14 @@
    ],
    "source": [
     "get_resnet_encoder(resnet50,labeled_train_dataset,image_size, image_channels, width, 4).summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6825a12b",
+   "metadata": {},
+   "source": [
+    "## Supervised baseline model"
    ]
   },
   {
@@ -677,6 +702,14 @@
     "        max(baseline_history.history[\"val_acc\"]) * 100\n",
     "    )\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9dc5f3f3",
+   "metadata": {},
+   "source": [
+    "## Self-supervised model for contrastive pretraining"
    ]
   },
   {
@@ -1185,6 +1218,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "4e2ea2e4",
+   "metadata": {},
+   "source": [
+    "## Supervised finetuning of the pretrained encoder - Student Net"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 12,
    "id": "d1a82998",
@@ -1437,7 +1478,6 @@
     }
    ],
    "source": [
-    "# Supervised finetuning of the pretrained encoder - Student Net\n",
     "finetuning_model = keras.Sequential(\n",
     "    [\n",
     "        layers.Input(shape=(image_size, image_size, image_channels)),\n",
@@ -1467,6 +1507,14 @@
     "        max(finetuning_history.history[\"val_acc\"]) * 100\n",
     "    )\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0ee615ff",
+   "metadata": {},
+   "source": [
+    "## Comparison against the baseline"
    ]
   },
   {
@@ -1523,6 +1571,14 @@
     "\n",
     "\n",
     "plot_training_curves(pretraining_history, finetuning_history, baseline_history)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "700eeb35",
+   "metadata": {},
+   "source": [
+    "## Save the models"
    ]
   },
   {
@@ -2148,7 +2204,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
2 changes:

1.  *grab_data* notebook 

- updated the paths from static to dynamic
- `unlabeled_data_20k_images` now has a folder `data`, in which 20k samples are put instead. This is to avoid the error given by `image_dataset_from_directory` in `prepare_dataset`. 

2. *simclr model V2* notebook
- `n_classes` argument in `get_resnet_encoder` is not used and removed. 